### PR TITLE
Expand the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,12 @@ jobs:
         title: MyReleaseMessage
 ```
 
-Please note, that you can't use `${{ secrets.GITHUB_TOKEN }}` as it isn't allowed to publish releases.
+## Notes
 
-## Argument
+You can't use `${{ secrets.GITHUB_TOKEN }}` as it isn't allowed to publish releases.
 
-The message which should appear in the release. May not contain spaces.
+The ``title`` field is a message which should appear in the release. May not contain spaces. 
+
+The reasult of running this action will be a new GitHub release of your software, available for download in the tab on the right.
+
+This release will contain the source code for the given tag, and also may contain binaries and supporting metadata, if those are installed in directory so-and-so. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Actions Status](https://github.com/elgohr/Github-Release-Action/workflows/Release/badge.svg)](https://github.com/elgohr/Github-Release-Action/actions)
 
-Publish Github releases
+Creates a plain Github release, without attaching assets or source code.
 
 ## Usage
 
@@ -27,10 +27,6 @@ jobs:
 
 ## Notes
 
-You can't use `${{ secrets.GITHUB_TOKEN }}` as it isn't allowed to publish releases.
+`${{ secrets.GITHUB_TOKEN }}` can't be used for publishing, as it isn't allowed to publish releases.
 
 The ``title`` field is a message which should appear in the release. May not contain spaces. 
-
-The reasult of running this action will be a new GitHub release of your software, available for download in the tab on the right.
-
-This release will contain the source code for the given tag, and also may contain binaries and supporting metadata, if those are installed in directory so-and-so. 


### PR DESCRIPTION
This is a proposed addition to the documentation. I don't know much what your tool does, so the last sentence is speculative. 

I am looking for the ability to create a release having source code and binaries. I don't know if your tool does that, or it just releases source code. Anyhow, hopefully  you can use some of this text to expand what is there now, which is little for the moment. 