### PR TITLE
fix: Add option for tag and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         title: MyReleaseMessage
+        tag: MyTag
 ```
 
 ## Mandatory Arguments
@@ -34,6 +35,9 @@ jobs:
 
 ### workdir
 `workdir` can be used to specify a directory that contains the repository to be published. 
+
+### tag
+`tag` can be used to set the tag of the release
 
 ## Notes
 

--- a/action.yml
+++ b/action.yml
@@ -21,3 +21,4 @@ runs:
       env:
         INPUT_TITLE: ${{ inputs.title }}
         INPUT_WORKDIR: ${{ inputs.workdir }}
+        INPUT_TAG: ${{ inputs.tag }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@ if [ ! -z "${INPUT_WORKDIR}" ]; then
     cd "${INPUT_WORKDIR}"
 fi
 
-gh release create -t "${INPUT_TITLE}" "$(date +%Y%m%d%H%M%S)" --generate-notes
+gh release create $INPUT_TAG -t "${INPUT_TITLE}" "$(date +%Y%m%d%H%M%S)" --generate-notes


### PR DESCRIPTION
To allow for more extended capability, I have added `tag` and `notes` to the options

# Credit to 
- https://github.com/Coolchickenguy
- https://github.com/elgohr/Github-Release-Action/pull/54